### PR TITLE
Add ngrok command for local development

### DIFF
--- a/lstm-spam-api/app/main.py
+++ b/lstm-spam-api/app/main.py
@@ -1,5 +1,6 @@
 # This is the main module for the FastAPI application
 # uvicorn app.main:app --reload
+# ngrok http 8000
 
 import pathlib
 from typing import Optional


### PR DESCRIPTION
This pull request adds the ngrok command to the main.py file for local development. This command allows for tunneling of the FastAPI application to a public URL, making it accessible for testing and debugging purposes.